### PR TITLE
Changes to support variable sample periods for CPU statistics

### DIFF
--- a/source/code/include/scxsystemlib/cpuenumeration.h
+++ b/source/code/include/scxsystemlib/cpuenumeration.h
@@ -97,7 +97,7 @@ namespace SCXSystemLib
     class CPUEnumeration : public EntityEnumeration<CPUInstance>
     {
     public:
-        explicit CPUEnumeration(SCXCoreLib::SCXHandle<CPUPALDependencies> = SCXCoreLib::SCXHandle<CPUPALDependencies>(new CPUPALDependencies()) );
+        explicit CPUEnumeration(SCXCoreLib::SCXHandle<CPUPALDependencies> = SCXCoreLib::SCXHandle<CPUPALDependencies>(new CPUPALDependencies()), time_t = CPU_SECONDS_PER_SAMPLE, size_t = MAX_CPUINSTANCE_DATASAMPER_SAMPLES);
         ~CPUEnumeration();
         virtual void Init();
         virtual void Update(bool updateInstances=true);
@@ -147,6 +147,8 @@ namespace SCXSystemLib
         SCXCoreLib::SCXHandle<CPUPALDependencies> m_deps; //!< Collects external dependencies of this class.
         SCXCoreLib::SCXLogHandle m_log;         //!< Log handle.
         SCXCoreLib::SCXThreadLockHandle m_lock; //!< Handles locking in the cpu enumeration.
+        time_t m_sampleSecs;			//!< Number of seconds between samples
+        size_t m_sampleSize;                    //!< Number of elements stored in sample set
 
         SCXCoreLib::SCXHandle<SCXCoreLib::SCXThread> m_dataAquisitionThread; //!< Thread pointer.
         static void DataAquisitionThreadBody(SCXCoreLib::SCXThreadParamHandle& param);

--- a/source/code/include/scxsystemlib/cpuinstance.h
+++ b/source/code/include/scxsystemlib/cpuinstance.h
@@ -28,13 +28,13 @@
 namespace SCXSystemLib
 {
     /** Number of samples collected in the datasampler for CPU. */
-    const int MAX_CPUINSTANCE_DATASAMPER_SAMPLES = 6;
+    const size_t MAX_CPUINSTANCE_DATASAMPER_SAMPLES = 6;
 
     /** Datasampler for CPU information. */
 #if defined(aix)
-    typedef DataSampler<u_longlong_t, MAX_CPUINSTANCE_DATASAMPER_SAMPLES> CPUInstanceDataSampler;
+    typedef DataSampler<u_longlong_t> CPUInstanceDataSampler;
 #else
-    typedef DataSampler<scxulong, MAX_CPUINSTANCE_DATASAMPER_SAMPLES> CPUInstanceDataSampler;
+    typedef DataSampler<scxulong> CPUInstanceDataSampler;
 #endif
     /*----------------------------------------------------------------------------*/
     /**
@@ -49,7 +49,7 @@ namespace SCXSystemLib
 
     public:
 
-        CPUInstance(unsigned int procNumber, bool isTotal = false);
+        CPUInstance(unsigned int procNumber, size_t sampleSize, bool isTotal = false);
         virtual ~CPUInstance();
 
         const std::wstring& GetProcName() const;

--- a/source/code/include/scxsystemlib/memoryinstance.h
+++ b/source/code/include/scxsystemlib/memoryinstance.h
@@ -37,7 +37,7 @@ namespace SCXSystemLib
     const int MEMORY_SECONDS_PER_SAMPLE = 60;
 
     /** Datasampler for memory information. */
-    typedef DataSampler<scxulong, MAX_MEMINSTANCE_DATASAMPER_SAMPLES> MemoryInstanceDataSampler;
+    typedef DataSampler<scxulong> MemoryInstanceDataSampler;
 
     /*----------------------------------------------------------------------------*/
     /**

--- a/source/code/include/scxsystemlib/processinstance.h
+++ b/source/code/include/scxsystemlib/processinstance.h
@@ -216,15 +216,15 @@ namespace SCXSystemLib
     typedef scxulong scxpid_t;  //!< Internal type of process id
 
     /** Number of samples collected in the datasampler for CPU. */
-    const int MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES = 6;
+    const size_t MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES = 6;
 
     /** Datasampler for CPU information. */
-    typedef DataSampler<scxulong, MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES> ScxULongDataSampler_t;
+    typedef DataSampler<scxulong> ScxULongDataSampler_t;
     /** Datasampler for time stored as a struct timeval */
-    typedef DataSampler<struct timeval, MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES> TvDataSampler_t;
+    typedef DataSampler<struct timeval> TvDataSampler_t;
 #if defined(sun) || defined(aix)
     /** Datasampler for time stored as a scx_timestruc_t (which is specific for solaris&aix) */
-    typedef DataSampler<scx_timestruc_t, MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES> TsDataSampler_t;
+    typedef DataSampler<scx_timestruc_t> TsDataSampler_t;
 #endif
     
     /*----------------------------------------------------------------------------*/
@@ -244,6 +244,30 @@ namespace SCXSystemLib
         // This constructor is added for unit-test purposes (See WI 516119).
         // Never use this for general use; it is solely for unit testing specific issues!
         ProcessInstance(const std::string &cmd, const std::string &params)
+#if defined(linux)
+          : m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
+#elif defined(sun)
+          : m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_BlockOut_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_BlockInp_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
+#elif defined(hpux)
+          : m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_BlockOut_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_BlockInp_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
+#elif defined(aix)
+          : m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+            m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
+#endif
         {
 #if defined(linux)
             strncpy(m.command, cmd.c_str(), sizeof(m.command));

--- a/source/code/include/scxsystemlib/statisticaldiskinstance.h
+++ b/source/code/include/scxsystemlib/statisticaldiskinstance.h
@@ -34,7 +34,7 @@ namespace SCXSystemLib
     const int DISK_SECONDS_PER_SAMPLE = 60;
 
     /** Datasampler for disk information. */
-    typedef DataSampler<scxulong, MAX_DISKINSTANCE_DATASAMPER_SAMPLES> DiskInstanceDataSampler;
+    typedef DataSampler<scxulong> DiskInstanceDataSampler;
 
     /*----------------------------------------------------------------------------*/
     /**

--- a/source/code/scxsystemlib/cpu/cpuinstance.cpp
+++ b/source/code/scxsystemlib/cpu/cpuinstance.cpp
@@ -37,8 +37,17 @@ namespace SCXSystemLib
         Parameters:  procNumber - Number of processor, used as base for instance name
                      isTotal - Whether the instance represents a Total value of a collection
     */
-    CPUInstance::CPUInstance(unsigned int procNumber, bool isTotal) : EntityInstance(isTotal)
-    {
+    CPUInstance::CPUInstance(unsigned int procNumber, size_t sampleSize, bool isTotal)
+      : EntityInstance(isTotal),
+        m_UserCPU_tics(sampleSize),
+        m_NiceCPU_tics(sampleSize),
+        m_SystemCPUTime_tics(sampleSize),
+        m_IdleCPU_tics(sampleSize),
+        m_IOWaitTime_tics(sampleSize),
+        m_IRQTime_tics(sampleSize),
+        m_SoftIRQTime_tics(sampleSize),
+        m_Total_tics(sampleSize)
+   {
         m_log = SCXLogHandleFactory::GetLogHandle(L"scx.core.common.pal.system.cpu.cpuinstance");
 
         if (isTotal)

--- a/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
+++ b/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
@@ -32,7 +32,24 @@ namespace SCXSystemLib
    \returns     N/A
     
 */
-    StatisticalDiskInstance::StatisticalDiskInstance(SCXCoreLib::SCXHandle<DiskDepend> deps, bool isTotal /* = false*/) : EntityInstance(isTotal) , m_deps(0)
+    StatisticalDiskInstance::StatisticalDiskInstance(
+        SCXCoreLib::SCXHandle<DiskDepend> deps,
+        bool isTotal /* = false*/)
+      : EntityInstance(isTotal),
+        m_deps(0),
+        m_reads(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_writes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_transfers(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_tBytes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_rBytes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_wBytes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_waitTimes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_tTimes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_rTimes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_wTimes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_runTimes(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_timeStamp(MAX_DISKINSTANCE_DATASAMPER_SAMPLES),
+        m_qLengths(MAX_DISKINSTANCE_DATASAMPER_SAMPLES)
 #if defined(sun)
            , m_kstat(0)
 #endif

--- a/source/code/scxsystemlib/memory/memoryinstance.cpp
+++ b/source/code/scxsystemlib/memory/memoryinstance.cpp
@@ -517,8 +517,8 @@ namespace SCXSystemLib
         m_totalSwap(0),
         m_availableSwap(0),
         m_usedSwap(0),
-        m_pageReads(),
-        m_pageWrites(),
+        m_pageReads(MAX_MEMINSTANCE_DATASAMPER_SAMPLES),
+        m_pageWrites(MAX_MEMINSTANCE_DATASAMPER_SAMPLES),
 #if defined(sun)
         m_reservedMemoryIsSupported(false),
         m_kstat_lock_handle(std::wstring(L"MemoryInstance")),

--- a/source/code/scxsystemlib/process/processinstance.cpp
+++ b/source/code/scxsystemlib/process/processinstance.cpp
@@ -295,8 +295,12 @@ namespace SCXSystemLib
      */
     ProcessInstance::ProcessInstance(scxpid_t pid, const char* basename) :
         EntityInstance(false), m_pid(pid), m_found(true), m_accessViolationEncountered(false),
-        m_scxPriorityValid(false), m_scxPriority(0), m_uid(0), m_gid(0), m_delta_UserTime(0), m_delta_SystemTime(0),
-        m_delta_HardPageFaults(0)
+        m_scxPriorityValid(false), m_scxPriority(0), m_uid(0), m_gid(0),
+        m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_delta_UserTime(0), m_delta_SystemTime(0), m_delta_HardPageFaults(0)
     {
         m_log = SCXLogHandleFactory::GetLogHandle(moduleIdentifier);
         SCX_LOGHYSTERICAL(m_log, L"ProcessInstance constructor");
@@ -521,7 +525,13 @@ namespace SCXSystemLib
     ProcessInstance::ProcessInstance(scxpid_t pid, const char* basename) :
         EntityInstance(false), m_pid(pid), m_found(true), m_accessViolationEncountered(false),
         m_scxPriorityValid(false), m_scxPriority(0), m_logged64BitError(false), m_delta_BlockOut(0),
-        m_delta_BlockInp(0), m_delta_HardPageFaults(0)
+        m_delta_BlockInp(0), m_delta_HardPageFaults(0),
+        m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_BlockOut_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_BlockInp_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
     {
         m_log = SCXLogHandleFactory::GetLogHandle(moduleIdentifier);
         SCX_LOGTRACE(m_log, L"ProcessInstance constructor");
@@ -875,7 +885,13 @@ namespace SCXSystemLib
     ProcessInstance::ProcessInstance(scxpid_t pid, struct pst_status *) :
         EntityInstance(false), m_pid(pid), m_found(true), m_accessViolationEncountered(false),
         m_scxPriorityValid(false), m_scxPriority(0), m_delta_UserTime(0), m_delta_SystemTime(0), m_delta_BlockOut(0),
-        m_delta_BlockInp(0), m_delta_HardPageFaults(0)
+        m_delta_BlockInp(0), m_delta_HardPageFaults(0),
+        m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_BlockOut_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_BlockInp_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_HardPageFaults_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
     {
         m_log = SCXLogHandleFactory::GetLogHandle(moduleIdentifier);
         SCX_LOGTRACE(m_log, L"ProcessInstance constructor");
@@ -1045,7 +1061,10 @@ namespace SCXSystemLib
      */
     ProcessInstance::ProcessInstance(scxpid_t pid, struct procentry64 *procInfo) :
         EntityInstance(false), m_pid(pid), m_found(true), m_accessViolationEncountered(false),
-        m_scxPriorityValid(false), m_scxPriority(0)
+        m_scxPriorityValid(false), m_scxPriority(0),
+        m_RealTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_UserTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES),
+        m_SystemTime_tics(MAX_PROCESSINSTANCE_DATASAMPER_SAMPLES)
     {
         m_log = SCXLogHandleFactory::GetLogHandle(moduleIdentifier);
         SCX_LOGTRACE(m_log, L"ProcessInstance constructor");

--- a/test/code/scxsystemlib/datasampler_test.cpp
+++ b/test/code/scxsystemlib/datasampler_test.cpp
@@ -44,7 +44,7 @@ public:
 
     void testAddSample()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         CPPUNIT_ASSERT(0 == test.GetNumberOfSamples());
         test.AddSample(1);
         CPPUNIT_ASSERT(1 == test.GetNumberOfSamples());
@@ -64,7 +64,7 @@ public:
 
     void testHasWrapped()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         CPPUNIT_ASSERT(!test.HasWrapped(5));
         test.AddSample(10);
         CPPUNIT_ASSERT(!test.HasWrapped(5));
@@ -90,7 +90,7 @@ public:
 
     void testGetAverage()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         
         CPPUNIT_ASSERT(0 == test.GetAverage<int>());
 
@@ -109,7 +109,7 @@ public:
 
     void testGetAverageDelta()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         
         // With 0 samples, the average delta should be 0.
         CPPUNIT_ASSERT(0 == test.GetAverageDelta(0));
@@ -148,7 +148,7 @@ public:
 
     void testGetAverageDeltaFactored ()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         test.AddSample(10);
         test.AddSample(20);
         CPPUNIT_ASSERT_EQUAL(420, test.GetAverageDeltaFactored(2, 42));
@@ -156,7 +156,7 @@ public:
     
     void testGetDelta ()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         test.AddSample(2);
         test.AddSample(2);
         test.AddSample(4);
@@ -165,7 +165,7 @@ public:
 
     void testGetAt ()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         test.AddSample(1);
         test.AddSample(2);
         test.AddSample(3);
@@ -179,7 +179,7 @@ public:
 
     void testClear ()
     {
-        DataSampler<int, 5> test;
+        DataSampler<int> test(5);
         CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), test.GetNumberOfSamples());
         test.Clear();
         CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(0), test.GetNumberOfSamples());


### PR DESCRIPTION
@MSFTOSSMgmt/omsdevs 

Changes to PAL infrastructure to support variable number of samples (and variable sample time) for CPU provider. The DataSampler class is modified, so if we need this down the road for other classes, it should be easier to handle.
