### PR TITLE
Add a newline (\n) to package_filename file

### DIFF
--- a/installer/InstallBuilder/aixlpp.py
+++ b/installer/InstallBuilder/aixlpp.py
@@ -197,5 +197,5 @@ class AIXLPPFile:
             exit(1)
 
         package_filename = open(self.targetDir + "/" + "package_filename", 'w')
-        package_filename.write(lppbasefilename)
+        package_filename.write("%s\n" % lppbasefilename)
         package_filename.close()

--- a/installer/InstallBuilder/hpuxpackage.py
+++ b/installer/InstallBuilder/hpuxpackage.py
@@ -187,5 +187,5 @@ RestoreConfigurationFile() {
             exit(1)
 
         package_filename = open(self.targetDir + "/" + "package_filename", 'w')
-        package_filename.write(depotbasefilename)
+        package_filename.write("%s\n" % depotbasefilename)
         package_filename.close()

--- a/installer/InstallBuilder/linuxdpkg.py
+++ b/installer/InstallBuilder/linuxdpkg.py
@@ -166,5 +166,5 @@ class LinuxDebFile:
             exit(1)
 
         package_filename = open(self.targetDir + "/" + "package_filename", 'w')
-        package_filename.write(pkgName)
+        package_filename.write("%s\n" % pkgName)
         package_filename.close()

--- a/installer/InstallBuilder/linuxrpm.py
+++ b/installer/InstallBuilder/linuxrpm.py
@@ -161,7 +161,7 @@ class LinuxRPMFile:
             exit(1)
 
         package_filename = open(self.targetDir + "/" + "package_filename", 'w')
-        package_filename.write(rpmNewFileName)
+        package_filename.write("%s\n" % rpmNewFileName)
         package_filename.close()
 
     def BuildPackage(self):

--- a/installer/InstallBuilder/sunospkg.py
+++ b/installer/InstallBuilder/sunospkg.py
@@ -137,7 +137,7 @@ class SunOSPKGFile:
             exit(1)
 
         package_filename = open(self.targetDir + "/" + "package_filename", 'w')
-        package_filename.write(basepkgfilename)
+        package_filename.write("%s\n" % basepkgfilename)
         package_filename.close()
 
 class PKGInfoFile:


### PR DESCRIPTION
@MSFTOSSMgmt/omsdevs 

sed on UNIX is very intolerant of lines without \n bytes at the end. Fix package_filename in installbuilder to include \n at the end of the line.
