### PR TITLE
Establish (and use) a strerror() replacement for safety

### DIFF
--- a/build/Makefile.scxcorelib
+++ b/build/Makefile.scxcorelib
@@ -47,6 +47,7 @@ STATIC_CORELIB_SRCFILES = \
 	$(CORELIB_ROOT)/util/scxexception.cpp \
 	$(CORELIB_ROOT)/util/scxmath.cpp \
 	$(CORELIB_ROOT)/util/utftoupper.cpp \
+	$(CORELIB_ROOT)/util/strerror.cpp \
 	$(CORELIB_ROOT)/util/stringaid.cpp \
 	$(CORELIB_ROOT)/util/log/scxlogfilebackend.cpp \
 	$(CORELIB_ROOT)/util/log/scxlogstdoutbackend.cpp \

--- a/source/code/include/scxcorelib/scxcmn.h
+++ b/source/code/include/scxcorelib/scxcmn.h
@@ -103,6 +103,10 @@ typedef uint64_t scxulong;
 /* Include scxcompat.h so it can be used without special requirements */
 #include <scxcorelib/scxcompat.h>
 
+/* Include strerror.h so consumers must be clear on what version to use */
+/* (Can't imagine a case where they's want the system one, but do give a choice) */
+#include <scxcorelib/strerror.h>
+
 // Based on g++ usage for Red Hat and SuSE, it appears that GCC v4.4 and later don't need to disable dynamic_cast. So the last condition was added at the end.
 
 // At this point, we THINK dynamic_cast is okay ... but keep this in code "just in case"

--- a/source/code/include/scxcorelib/scxexception.h
+++ b/source/code/include/scxcorelib/scxexception.h
@@ -19,6 +19,7 @@
 
 #include <scxcorelib/scxcmn.h>
 #include <scxcorelib/scxassert.h>
+#include <scxcorelib/strerror.h>
 
 #include <string.h>
 
@@ -454,24 +455,7 @@ namespace SCXCoreLib
         SCXErrnoException(std::wstring fkncall, int errno_, const SCXCodeLocation& l) 
             : SCXException(l), m_fkncall(fkncall), m_errno(errno_)
         { 
-            char buf[80];
-#ifdef WIN32
-            strerror_s(buf, sizeof(buf), errno_);
-            m_errtext = buf;
-#elif (defined(hpux) && (PF_MINOR==23)) || (defined(sun) && (PF_MAJOR==5) && (PF_MINOR<=9))
-            // WI7938
-            m_errtext = strerror(errno_);
-#elif (defined(hpux) && (PF_MINOR>23)) || (defined(sun) && (PF_MAJOR==5) && (PF_MINOR>9)) || (defined(aix)) || (defined(macos))
-            int r = strerror_r(errno_, buf, sizeof(buf));
-            if (0 != r) {
-                snprintf(buf, sizeof(buf), "Unknown error %d", errno_);
-            }
-            m_errtext = buf;
-#else
-            // Do not assign to m_errtext directly to get compiler error when strerror_r is declared to return an int.
-            char* r = strerror_r(errno_, buf, sizeof(buf)); 
-            m_errtext = r;
-#endif
+            m_errtext = SCXCoreLib::strerror(errno_);
         };
 
         std::wstring What() const {

--- a/source/code/include/scxcorelib/strerror.h
+++ b/source/code/include/scxcorelib/strerror.h
@@ -1,0 +1,31 @@
+/*------------------------------------------------------------------------------
+    Copyright (c) Microsoft Corporation. All rights reserved. See license.txt for license information.
+
+*/
+/**
+    \file
+
+    \brief     Portable interface for strerror() function
+
+    \date      01-27-16 16:30:00
+
+    strerror() helper functions
+
+    \note      These functions are implemented without other PAL dependencies.
+               This aids compatibility with programs like OMI's pre-exec
+               program, which does not link against the PAL.
+*/
+/*----------------------------------------------------------------------------*/
+
+#ifndef SCXSTRERROR_H
+#define SCXSTRERROR_H
+
+#include <string>
+
+namespace SCXCoreLib
+{
+    std::string strerror(int errnum);
+}
+
+#endif /* SCXSTRERROR_H */
+/*----------------------------E-N-D---O-F---F-I-L-E---------------------------*/

--- a/source/code/scxcorelib/pal/scxdirectoryinfo.cpp
+++ b/source/code/scxcorelib/pal/scxdirectoryinfo.cpp
@@ -19,6 +19,7 @@
 #include <scxcorelib/scxexception.h>
 #include <scxcorelib/scxdirectoryinfo.h>
 #include <scxcorelib/scxfile.h>
+#include <scxcorelib/strerror.h>
 
 #include <string>
 #include <vector>
@@ -460,7 +461,7 @@ namespace
                     throw SCXCoreLib::SCXFilePathNotFoundException(path.GetDirectory(), SCXSRCLOCATION);
                 }
 
-                std::string errtxt(strerror(eno));
+                std::string errtxt(SCXCoreLib::strerror(eno));
 
                 if (eno == EACCES || eno == ENOTDIR) {
                     throw SCXCoreLib::SCXInvalidArgumentException(wdirname, SCXCoreLib::StrFromUTF8(errtxt), SCXSRCLOCATION);

--- a/source/code/scxcorelib/util/strerror.cpp
+++ b/source/code/scxcorelib/util/strerror.cpp
@@ -1,0 +1,57 @@
+/*------------------------------------------------------------------------------
+    Copyright (c) Microsoft Corporation. All rights reserved. See license.txt for license information.
+
+*/
+/**
+    \file
+
+    \brief     Portable interface for strerror() function
+
+    \date      01-27-16 16:30:00
+
+    strerror() helper functions
+
+    \note      These functions are implemented without other PAL dependencies.
+               This aids compatibility with programs like OMI's pre-exec
+               program, which does not link against the PAL.
+*/
+/*----------------------------------------------------------------------------*/
+
+#include <scxcorelib/strerror.h>
+
+#include <string.h>
+#include <string>
+
+namespace SCXCoreLib
+{
+    std::string strerror(int errnum)
+    {
+        std::string result;
+
+#ifdef WIN32
+        char buf[128];
+        strerror_s(buf, sizzeof(buf), errnum);
+        result = buf;
+#elif (defined(hpux) && (PF_MINOR==23)) || (defined(sun) && (PF_MAJOR==5) && (PF_MINOR<=9))
+        // WI7938
+        result = strerror(errnum);
+#elif (defined(hpux) && (PF_MINOR>23)) || (defined(sun) && (PF_MAJOR==5) && (PF_MINOR>9)) || (defined(aix)) || (defined(macos))
+        char buf[128];
+        int r = strerror_r(errnum, buf, sizeof(buf));
+        if (0 != r) {
+            snprintf(buf, buflen, "Unknown error %d", errnum);
+        }
+        result = buf;
+#else
+        char buf[128];
+        // Do not assign return value directly to avoid compiler error when
+        // strerror_r is declared to return an int.
+        char* r = strerror_r(errnum, buf, sizeof(buf));
+        result = r;
+#endif
+
+        return result;
+    }
+}
+
+/*----------------------------E-N-D---O-F---F-I-L-E---------------------------*/

--- a/source/code/scxsystemlib/networkinterface/networkinterface.cpp
+++ b/source/code/scxsystemlib/networkinterface/networkinterface.cpp
@@ -19,6 +19,8 @@
 #include <scxcorelib/scxexception.h>
 #include <scxcorelib/scxdumpstring.h>
 #include <scxcorelib/logsuppressor.h>
+#include <scxcorelib/strerror.h>
+
 #include <sstream>
 #include <iomanip>
 
@@ -203,7 +205,7 @@ using namespace SCXCoreLib;
 
     wstring wstrerror(int err)
     {
-        return SCXCoreLib::StrFromUTF8(strerror(err));
+        return SCXCoreLib::StrFromUTF8(SCXCoreLib::strerror(err));
     }
 
 #if defined(sun)

--- a/test/code/scxcorelib/pal/scxfile_test.cpp
+++ b/test/code/scxcorelib/pal/scxfile_test.cpp
@@ -517,7 +517,7 @@ class SCXFileTest : public CPPUNIT_NS::TestFixture {
         regfree(&re);
 
         errno = eno;
-        CPPUNIT_ASSERT_MESSAGE(strerror(eno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(eno), errno == 0);
 
         return success;
     }

--- a/test/code/scxcorelib/util/scxexception_test.cpp
+++ b/test/code/scxcorelib/util/scxexception_test.cpp
@@ -734,9 +734,9 @@ public:
         SCXHandle<SCXErrnoException> e(new SCXErrnoException(L"FUNCTION", EINVAL, SCXSRCLOCATION));
         VerifyException(e, L"FUNCTION");
         VerifyException(e, StrFrom(EINVAL));
-        VerifyException(e, StrFromUTF8(strerror(EINVAL)));
+        VerifyException(e, StrFromUTF8(SCXCoreLib::strerror(EINVAL)));
         CPPUNIT_ASSERT_EQUAL(EINVAL, e->ErrorNumber());
-        CPPUNIT_ASSERT_EQUAL(string(strerror(EINVAL)), e->ErrorText());
+        CPPUNIT_ASSERT_EQUAL(SCXCoreLib::strerror(EINVAL), e->ErrorText());
     }
 
     void CoverageForErrnoFileException()
@@ -745,7 +745,7 @@ public:
         VerifyException(e, L"FUNCTION");
         VerifyException(e, L"PATH");
         VerifyException(e, StrFrom(EINVAL));
-        VerifyException(e, StrFromUTF8(strerror(EINVAL)));
+        VerifyException(e, StrFromUTF8(SCXCoreLib::strerror(EINVAL)));
         VerifyException(e, e->GetFnkcall());
         VerifyException(e, e->GetPath());
     }

--- a/test/code/scxsystemlib/memory/memoryinstance_test.cpp
+++ b/test/code/scxsystemlib/memory/memoryinstance_test.cpp
@@ -934,7 +934,7 @@ class MemoryInstance_Test : public CPPUNIT_NS::TestFixture
         struct pst_static psts;
         errno = 0;
         CPPUNIT_ASSERT(pstat_getstatic(&psts, sizeof(psts), (size_t)1, 0) > 0);
-        CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
 
         keyValues["TotalMemory"] = psts.physical_memory * 4; // From 4K pages to 1K.
 
@@ -967,14 +967,14 @@ class MemoryInstance_Test : public CPPUNIT_NS::TestFixture
         std::string cmd = topcmd + std::string(tmpnambuf);
 
         if (system(cmd.c_str()) < 0) {
-            CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+            CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
             return;
         }
 
         /* Now read the output */
         FILE *topFile = fopen(tmpnambuf, "r");
         if (topFile == 0) {
-            CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+            CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
             return;
         }
 
@@ -997,7 +997,7 @@ class MemoryInstance_Test : public CPPUNIT_NS::TestFixture
         fclose(topFile);
         remove(tmpnambuf);
         errno = eno;            // Just for documentation purposes!
-        CPPUNIT_ASSERT_MESSAGE(strerror(eno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(eno), errno == 0);
         CPPUNIT_ASSERT_MESSAGE("Didn't get expected values from top", done);
     }
 
@@ -1041,7 +1041,7 @@ class MemoryInstance_Test : public CPPUNIT_NS::TestFixture
         if (!feof(swapinfoFile)) { eno = errno; }
         pclose(swapinfoFile);
         errno = eno;            // Just for documentation purposes!
-        CPPUNIT_ASSERT_MESSAGE(strerror(eno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(eno), errno == 0);
         CPPUNIT_ASSERT_MESSAGE("Didn't get expected values from swapinfo", done);
     }
 

--- a/test/code/scxsystemlib/process/processpal_test.cpp
+++ b/test/code/scxsystemlib/process/processpal_test.cpp
@@ -1823,7 +1823,7 @@ public:
         FILE* psEFile = popen(psecmd, "r");
         if (psEFile == 0) {
             CPPUNIT_ASSERT_MESSAGE("Can't do popen", psEFile);
-            CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+            CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
             return;
         }
 
@@ -1894,7 +1894,7 @@ public:
         if (!feof(psEFile)) { eno = errno; }
         pclose(psEFile);
         errno = eno;            // Just for documentation purposes!
-        CPPUNIT_ASSERT_MESSAGE(strerror(eno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(eno), errno == 0);
     }
 
     /**
@@ -1928,7 +1928,7 @@ public:
         FILE* psEFile = popen(psecmd, "r");
         if (psEFile == 0) {
             CPPUNIT_ASSERT_MESSAGE("Can't do popen", psEFile);
-            CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+            CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
             return;
         }
 
@@ -1955,7 +1955,7 @@ public:
         if (!feof(psEFile)) { eno = errno; }
         pclose(psEFile);
         errno = eno;            // Just for documentation purposes!
-        CPPUNIT_ASSERT_MESSAGE(strerror(eno), errno == 0);
+        CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(eno), errno == 0);
         CPPUNIT_ASSERT_MESSAGE("Didn't find pid", done);
     }
 
@@ -1985,7 +1985,7 @@ public:
         if (psEFile == 0)
         {
             CPPUNIT_ASSERT(psEFile);
-            CPPUNIT_ASSERT_MESSAGE(strerror(errno), errno == 0);
+            CPPUNIT_ASSERT_MESSAGE(SCXCoreLib::strerror(errno), errno == 0);
             return;
         }
 


### PR DESCRIPTION
Create new SCXCoreLib::strerror() function, compatible with the system ::strerror() function, but safe on all platforms (except old HP, where we can't do anything about it since strerror_r() isn't available).

Note that unit tests for this new function are not needed. The basis for this code came from scxexception.h, and the code is called directly from scxexception.h. Since scxexception.h has great unit tests that call the new code, it's directly tested.

@Microsoft/ostc-devs 
