### PR TITLE
Updates for ULINUX build on Ubuntu.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -7,6 +7,7 @@
 
 # Set up architecture and Build Root Directory
 # PF (i.e. PlatForm) is either linux, solaris
+SHELL=/bin/bash
 PWD:=$(shell pwd)
 SCX_BRD=$(subst /build,,$(PWD))
 PF_POSIX=true

--- a/source/code/scxsystemlib/common/scxostypeinfo.cpp
+++ b/source/code/scxsystemlib/common/scxostypeinfo.cpp
@@ -52,7 +52,7 @@ using namespace SCXCoreLib;
 
 namespace {
 
-#if defined(linux)
+#if defined(linux) && defined(PF_DISTRO_SUSE)
     /**
        Extracts the distribution specific OS name.
 


### PR DESCRIPTION
Makefile - Add SHELL=/bin/bash.
In source/code/scxsystemlib/common/scxostypeinfo.cpp - prevent warning when ULINUX is built on other than SuSE.

@Microsoft/ostc-devs