### PR TITLE
Fix problem identifying Red Hat systems properly in SCX_OperatingSystem

### DIFF
--- a/source/code/scxsystemlib/common/GetLinuxOS.sh
+++ b/source/code/scxsystemlib/common/GetLinuxOS.sh
@@ -89,6 +89,7 @@ GetLinuxInfo() {
         if [ "${Version}" != "" ]; then
             OSAlias="RHEL"
             OSManufacturer="Red Hat, Inc."
+            OSFullName=`cat $ReleaseFile`
         fi
     elif [ "${OSName}" = "SUSE Linux Enterprise Server" ]; then
         # SLES 10 uses "Linux". Need to parse the minor version as SLES 10.0 is not supported, only 10.1 and up
@@ -265,8 +266,10 @@ GetLinuxInfo() {
         Version="$Version.0"
     fi
 
-    # Construct OSFullName string
-    OSFullName="$OSName $Version ($Arch)"
+    if [ -z "$OSFullName" ]; then
+        # Construct OSFullName string
+        OSFullName="$OSName $Version ($Arch)"
+    fi
 }
 
 ## End Linux distro function

--- a/test/code/scxsystemlib/common/getlinuxos_test.cpp
+++ b/test/code/scxsystemlib/common/getlinuxos_test.cpp
@@ -44,6 +44,7 @@ class SCXGetLinuxOS_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( TestDisableFileDisables );
     CPPUNIT_TEST( TestNoReleaseFile );
     CPPUNIT_TEST( TestPlatform_RHEL_61 );
+    CPPUNIT_TEST( TestPlatform_RHEL_70 );
     CPPUNIT_TEST( TestPlatform_SLES_9_0 );
     CPPUNIT_TEST( TestPlatform_SLES_10 );
     CPPUNIT_TEST( TestPlatform_Oracle_5 );
@@ -228,13 +229,34 @@ public:
         // Verify our data:
         //      OSName=Red Hat Enterprise Linux
         //      OSVersion=6.1
-        //      OSFullName=Red Hat Enterprise Linux 6.1 (x86_64)
+        //      OSFullName=Red Hat Enterprise Linux Server release 6.1 (Santiago)
         //      OSAlias=RHEL
         //      OSManufacturer=Red Hat, Inc.
 
         CPPUNIT_ASSERT_EQUAL( string("Red Hat Enterprise Linux"), releaseFile["OSName"] );
         CPPUNIT_ASSERT_EQUAL( string("6.1"), releaseFile["OSVersion"] );
-        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("Red Hat Enterprise Linux 6.1") );
+        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("Red Hat Enterprise Linux Server release 6.1 (Santiago)") );
+        CPPUNIT_ASSERT_EQUAL( string("RHEL"), releaseFile["OSAlias"] );
+        CPPUNIT_ASSERT_EQUAL( string("Red Hat, Inc."), releaseFile["OSManufacturer"] );
+    }
+
+    // Platform RHEL version 7.0:
+    void TestPlatform_RHEL_70()
+    {
+        SelfDeletingFilePath delReleaseFile( s_wsReleaseFile );
+        map<string,string> releaseFile;
+        ExecuteScript( L"./testfiles/platforms/rhel_7.0", releaseFile );
+
+        // Verify our data:
+        //      OSName=Red Hat Enterprise Linux
+        //      OSVersion=7.0
+        //      OSFullName=Red Hat Enterprise Linux Server release 7.0 (Maipo)
+        //      OSAlias=RHEL
+        //      OSManufacturer=Red Hat, Inc.
+
+        CPPUNIT_ASSERT_EQUAL( string("Red Hat Enterprise Linux"), releaseFile["OSName"] );
+        CPPUNIT_ASSERT_EQUAL( string("7.0"), releaseFile["OSVersion"] );
+        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("Red Hat Enterprise Linux Server release 7.0 (Maipo)") );
         CPPUNIT_ASSERT_EQUAL( string("RHEL"), releaseFile["OSAlias"] );
         CPPUNIT_ASSERT_EQUAL( string("Red Hat, Inc."), releaseFile["OSManufacturer"] );
     }

--- a/test/code/scxsystemlib/common/platforms/rhel_7.0/os-release
+++ b/test/code/scxsystemlib/common/platforms/rhel_7.0/os-release
@@ -1,0 +1,15 @@
+NAME="Red Hat Enterprise Linux Server"
+VERSION="7.0 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="7.0"
+PRETTY_NAME="Red Hat Enterprise Linux Server 7.0 (Maipo)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.0:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.0
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION=7.0

--- a/test/code/scxsystemlib/common/platforms/rhel_7.0/redhat-release
+++ b/test/code/scxsystemlib/common/platforms/rhel_7.0/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux Server release 7.0 (Maipo)


### PR DESCRIPTION
Since 2016 TP5 kits can be used in 2012R2, the caption for the
SCX_OperatingSystem class has to be compatible with the 2012R2 MPs.
This change allows the caption to be compatible by fetching the
OSFullName parameter from the /etc/redhat-release file (which is
what older 2012R2 kits did).

@Microsoft/ostc-devs 