### PR TITLE
No longer reset network interface counters on AIX

### DIFF
--- a/source/code/scxsystemlib/networkinterface/networkinterface.cpp
+++ b/source/code/scxsystemlib/networkinterface/networkinterface.cpp
@@ -1521,14 +1521,6 @@ static SCXCoreLib::LogSuppressor suppressor(SCXCoreLib::eError, SCXCoreLib::eTra
             return;
         }
 
-        // Reset the driver counters.
-        if (deps->ioctl(s,NDD_CLEAR_STATS,NULL) < 0) 
-        {
-            SCXCoreLib::SCXErrnoException e(L"ioctl(s,NDD_CLEAR_STATS,NULL) failed. errno: ", errno, SCXSRCLOCATION);
-            SCX_LOGERROR(m_log, e.What());
-            return;
-        }
-
         // Populate the ioctl argument accordingly. 
         // The ioctl argument for the stat related commands must be struct nddctl.
         nddctl ioctl_arg;


### PR DESCRIPTION
Network interface stats can be retrieved with a command like:
    netstat -v | grep -i elap

On AIX, when enumerating network statistics via omicli like:
   omicli ei root/scx SCX_EthernetPortStatistics
then the network statistics were being reset. This was due a a
deliberate ioctl to reset the network stats. While there was a
comment to that effect, there was no explanation as to WHY this
was being done.

Still waiting for testing on this, so this is really just to practice with CodeFlow at this time.