### PR TITLE
Added tmpdir link support

### DIFF
--- a/source/code/include/scxcorelib/scxfile.h
+++ b/source/code/include/scxcorelib/scxfile.h
@@ -95,7 +95,7 @@ namespace SCXCoreLib {
         static void SeekG(std::wfstream& source, std::wstreampos pos);
 
 #if !defined(DISABLE_WIN_UNSUPPORTED)        
-        static SCXFilePath CreateTempFile(const std::wstring& fileContent);
+        static SCXFilePath CreateTempFile(const std::wstring& fileContent, const std::wstring& tmpDir=L"/tmp/");
 #endif
 
         static SCXStream::NLF GetPreferredNewLine(const SCXFilePath&);

--- a/source/code/scxcorelib/pal/scxfile.cpp
+++ b/source/code/scxcorelib/pal/scxfile.cpp
@@ -22,6 +22,8 @@
 #include <sys/stat.h>
 #include <scxcorelib/scxoserror.h>
 #include <scxcorelib/scxexception.h>
+#include <scxcorelib/stringaid.h>
+#include <scxcorelib/scxdirectoryinfo.h>
 
 /** To use API mmap and munmap*/
 #include <sys/mman.h>
@@ -576,7 +578,7 @@ namespace SCXCoreLib {
         \returns    Complete path of newly created file.
 
      */
-    SCXFilePath SCXFile::CreateTempFile(const std::wstring& fileContent) {
+    SCXFilePath SCXFile::CreateTempFile(const std::wstring& fileContent, const std::wstring& tmpDir /* = "/tmp/" */) {
         /**
          * The code below behaves as it does because of limitations in the
          * various temp file functions.
@@ -611,7 +613,11 @@ namespace SCXCoreLib {
         free(fp);
         fp = 0;
 #else
-        pattern = SCXFileSystem::DecodePath("/tmp/");
+        pattern = SCXFileSystem::DecodePath(StrToUTF8(tmpDir));
+        if(!SCXCoreLib::SCXDirectory::Exists(pattern))
+        {
+        	throw SCXCoreLib::SCXFilePathNotFoundException(pattern.GetDirectory(), SCXSRCLOCATION);
+        }
 #endif
 
         pattern.SetFilename(L"scxXXXXXX");


### PR DESCRIPTION
@Microsoft/ostc-devs 

This is the PAL part of DCR to make monitoring script stored and executed from a custom location rather than hardcoded /tmp.

As part of the change a link /etc/opt/microsoft/scx/conf/tmpdir will be created during scx installation. It will point to /tmp by default. System admin can change this to point to any other location on the system.

PAL layer is updated to return the location of tmpDir  when RunAs provider requests for it. PAL layer later will store the script at the location.