### PR TITLE
Changes for building local and ULINUX on Debian/Ubuntu:

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -7,6 +7,7 @@
 
 # Set up architecture and Build Root Directory
 # PF (i.e. PlatForm) is either linux, solaris
+SHELL=/bin/bash
 PWD:=$(shell pwd)
 SCX_BRD=$(subst /build,,$(PWD))
 PF_POSIX=true

--- a/installer/InstallBuilder/linuxdpkg.py
+++ b/installer/InstallBuilder/linuxdpkg.py
@@ -166,9 +166,11 @@ class LinuxDebFile:
             return
 
         # Build the package - 'cd' to the directory where we want to store result
-        dpkg_path = 'dpkg'
         if "DPKG_LOCATION" in self.variables:
             dpkg_path = self.variables["DPKG_LOCATION"]
+        # Use the system's version of dpkg-deb if present.
+        if os.path.exists('/usr/bin/dpkg-deb'):
+            dpkg_path = '/usr/bin/dpkg-deb'
         retval = os.system('cd ' + self.targetDir + '; ' + dpkg_path  + ' -b ' + self.stagingDir + ' ' + pkgName)
         if retval != 0:
             print("Error: Failed building DPKG")

--- a/source/code/scxsystemlib/common/scxostypeinfo.cpp
+++ b/source/code/scxsystemlib/common/scxostypeinfo.cpp
@@ -52,7 +52,7 @@ using namespace SCXCoreLib;
 
 namespace {
 
-#if defined(linux)
+#if defined(linux) && !defined(PF_DISTRO_ULINUX)
     /**
        Extracts the distribution specific OS name.
 


### PR DESCRIPTION
Makefile - Add SHELL=/bin/bash.  Debian variants default to /bin/sh, which breaks brace expansion.

linuxdpkg.py - Use system's version of dpkg-deb if present.  This prevents strange bug when using the pal's version of dpkg-deb-x64 on Debian/Ubuntu systems.

scxostypeinfo.cpp - Prevent definition of Linux ExtractOSName() if building ULINUX.  Otherwise a gcc warn-error complains of 'unused' function and stops the compilation.

@jeffaco  - I'd do the pbuild myself if I could - I think we need one before merging this...