### PR TITLE
Fixing Bug#6362479 - dmSlave traversal

### DIFF
--- a/source/code/scxsystemlib/disk/diskdepend.cpp
+++ b/source/code/scxsystemlib/disk/diskdepend.cpp
@@ -1451,11 +1451,11 @@ namespace SCXSystemLib
             while (path.GetFilename().length() > 0)
             {
                 physical_dev = RemoveTailNumberOrOther(physical_dev);
-                if (this->FileExists(physical_dev))
+                path = physical_dev;
+                if (this->FileExists(physical_dev) && path.GetFilename().length() > 0)
                 {
                     return physical_dev;
                 }
-                path = physical_dev;
             }
             return logical_dev;
         }


### PR DESCRIPTION
GetDMSlaves results in an erroneous output if the slave of a dm-device is also a dm-device. In such cases, we must traverse to the slaves till we reach a physical disk.
Two tests are introduced to test this functionality to test positive and negative scenarios.
Also included is a minor fix in diskdepend.cpp, which results in empty name under some rare circumstances.