### PR TITLE
Fix SCX_DiskDrive enumerate instance on Ubuntu

### DIFF
--- a/source/code/scxsystemlib/disk/diskdepend.cpp
+++ b/source/code/scxsystemlib/disk/diskdepend.cpp
@@ -663,7 +663,7 @@ namespace SCXSystemLib
             L"dev",
 #endif
 #if defined(linux)
-            L"devtmpfs",
+            L"devtmpfs", L"efivarfs", L"fuse.lxcfs",
 #endif
             L"eventpollfs",
             L"fd", L"ffs", L"fifofs", L"fusectl", L"futexfs",

--- a/test/code/scxsystemlib/disk/diskpal_test.cpp
+++ b/test/code/scxsystemlib/disk/diskpal_test.cpp
@@ -1271,7 +1271,7 @@ public:
             L"dev",
 #endif
 #if defined(linux)
-            L"devtmpfs",
+            L"devtmpfs", L"efivarfs", L"fuse.lxcfs",
 #endif
             L"eventpollfs",
             L"fd", L"ffs", L"fifofs", L"fusectl", L"futexfs",


### PR DESCRIPTION
@Microsoft/ostc-devs

This commit fixes Bug [7554508](https://microsoft.visualstudio.com/defaultcollection/WSSC/_workitems?_a=edit&id=7554508&triage=true)

Explanation of fix:

On Ubuntu 16.04 enumerate instances for SCX_DiskDrive was failing.
On debugging the issue I found that certain entries in /etc/mtab file that does not correspond to a physical/logical disk were erroneously considered as physical disks. This was causing the failure.
To fix this I added filesystem fuse.lxcfs (Filesystem for the entry causing the issue) in the File System’s to be ignored list.
I also saw this issue on Ubuntu 14.04 too.
To fix this I added efivarfs in ignored file system’s list. 

mtab entry on Ubuntu 16.04 was:
lxcfs /var/lib/lxcfs fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0

mtab entry on Ubuntu 14.04 was:
none /sys/firmware/efi/efivars efivars rw 0 0

With these changes all unit tests passed on Ubuntu 16.04 server and I ran PBUILD for other systems which was clean.

I have verified SCX_DiskDrive works fine on Ubuntu 16.04, 15.10 and 14.04
