### PR TITLE
    Changes for building local and ULINUX on Debian/Ubuntu:

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -7,6 +7,7 @@
 
 # Set up architecture and Build Root Directory
 # PF (i.e. PlatForm) is either linux, solaris
+SHELL=/bin/bash
 PWD:=$(shell pwd)
 SCX_BRD=$(subst /build,,$(PWD))
 PF_POSIX=true

--- a/source/code/scxsystemlib/common/scxostypeinfo.cpp
+++ b/source/code/scxsystemlib/common/scxostypeinfo.cpp
@@ -52,7 +52,7 @@ using namespace SCXCoreLib;
 
 namespace {
 
-#if defined(linux)
+#if defined(linux) && !defined(PF_DISTRO_ULINUX)
     /**
        Extracts the distribution specific OS name.
 


### PR DESCRIPTION
    Makefile - Add SHELL=/bin/bash.  Debian variants default to /bin/sh, which breaks brace expansion.

    scxostypeinfo.cpp - Prevent definition of Linux ExtractOSName() if building ULINUX.  Otherwise a gcc warn-error complains of 'unused' function and stops the compilation.

@jeffaco 
@niroyb 