### PR TITLE
Jfawcett power8 compile changes

### DIFF
--- a/source/code/scxcorelib/util/stringaid.cpp
+++ b/source/code/scxcorelib/util/stringaid.cpp
@@ -409,7 +409,8 @@ namespace SCXCoreLib
         // Note: This line may not indicate an error on some systems,
         // even if the number is negative.  Thus, we always check for
         // a minus sign (below) to guarentee consistent behavior.
-        bool conv_result = (ss >> tmp) != 0;
+        ss >> tmp;
+        bool conv_result = !ss.fail();
 
         wstringstream::pos_type s = ss.tellg();
 
@@ -440,7 +441,8 @@ namespace SCXCoreLib
         double tmp = 0;
         wstringstream ss(str);
 
-        bool conv_result = (ss >> tmp) != 0;
+        ss >> tmp;
+        bool conv_result = !ss.fail();
 
         if (!conv_result) {
             throw SCXCoreLib::SCXNotSupportedException(L"Cannot parse double in: '" + str + L"'", SCXSRCLOCATION);
@@ -462,7 +464,8 @@ namespace SCXCoreLib
         scxlong tmp;
         wstringstream ss(str);
 
-        bool conv_result = (ss >> tmp) != 0;
+        ss >> tmp;
+        bool conv_result = !ss.fail();
 
         if (!conv_result) {
             throw SCXCoreLib::SCXNotSupportedException(L"Cannot parse scxlong in: '" + str + L"'", SCXSRCLOCATION);
@@ -487,7 +490,8 @@ namespace SCXCoreLib
         // Note: This line may not indicate an error on some systems,
         // even if the number is negative.  Thus, we always check for
         // a minus sign (below) to guarentee consistent behavior.
-        bool conv_result = (ss >> tmp) != 0;
+        ss >> tmp;
+        bool conv_result = !ss.fail();
 
         wstringstream::pos_type s = ss.tellg();
 

--- a/source/code/scxsystemlib/common/scxostypeinfo.cpp
+++ b/source/code/scxsystemlib/common/scxostypeinfo.cpp
@@ -52,7 +52,7 @@ using namespace SCXCoreLib;
 
 namespace {
 
-#if defined(linux) && !defined(PF_DISTRO_ULINUX)
+#if defined(linux) && (defined(PF_DISTRO_SUSE) || defined(PF_DISTRO_REDHAT))
     /**
        Extracts the distribution specific OS name.
 

--- a/test/code/scxsystemlib/process/processpal_test.cpp
+++ b/test/code/scxsystemlib/process/processpal_test.cpp
@@ -1477,7 +1477,8 @@ public:
         // Convert stdout to numeric form
         stringstream ss( output.str() );
         int countPS(0);
-        bool conv_result = (ss >> countPS) != 0;
+        ss >> countPS;
+        bool conv_result = !ss.fail();
         CPPUNIT_ASSERT_EQUAL_MESSAGE( "Failure converting 'ps -ef | wc -l' to numeric form", true, conv_result );
         // Subtract 4 due to overhead from 'ps' command:
         //   The 'ps' command sequence creates three new processes (sh, ps, and wc)


### PR DESCRIPTION
A couple of changes necessary for compilation on the Power8 system.  These are generic changes that apply to all platforms, though.

Change 1:  When checking to see if a wstringstream operation completed successfully, we need to check the bad() operator, not the return value of the operation.

Change 2:  In scxostypeinfo, there was code that had been #ifdef'd out as ULINUIX.  This needed to be more specific, as the IBM was not ULINUX but also did not want the code.

@jeffaco @niroyb  please review