### PR TITLE
Nirsingh power8 pal

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -92,8 +92,11 @@ case $uname in
         case `uname -m` in
 	    # ARCH is only used for OMS to determine the correct ruby folder
 	    ppc64*)
-		PF_ARCH=ppc
-		ARCH=ppc
+                PF_ARCH=ppc
+                ARCH=ppc
+                VERSION=`grep 'Red Hat Enterprise' /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
+                PF_MAJOR=`echo $VERSION | sed s/[.][0-9]*\//`
+                PF_MINOR=`echo $VERSION | sed s/\[0-9]*[.]//`
 	    ;;
             *64*)
                 PF_ARCH=x64

--- a/installer/InstallBuilder/linuxrpm.py
+++ b/installer/InstallBuilder/linuxrpm.py
@@ -26,6 +26,7 @@ class LinuxRPMFile:
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/RPMS/i486"))
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/RPMS/i586"))
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/RPMS/i686"))
+        scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/RPMS/ppc64le"))
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/RPMS/noarch"))
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/SOURCES"))
         scxutil.MkAllDirs(os.path.join(self.intermediateDir, "RPM-packages/SPECS"))
@@ -133,7 +134,8 @@ class LinuxRPMFile:
 
         specfile.close()
 
-
+        if self.variables['PFDISTRO'] == 'ULINUX' and self.variables['PFARCH'] == 'ppc':
+            self.variables['PFDISTRO']='REDHAT'
     def StageAndProperlyNameRPM(self):
         if 'OUTPUTFILE' in self.variables:
             rpmNewFileName = self.variables['OUTPUTFILE'] + '.rpm'


### PR DESCRIPTION
Changes: 
----------
configure : We are calculating the PF_MAJOR and PF_MINOR as this is not a Universal linux, PF_MAJOR will be used in naming the rpm file.

linuxrpm.py: Calculating the name for the rpm file (scx-1.6.3-73.rhel.7.ppc.rpm) so that the PF_MAJOR can be used in the FileName.

@Microsoft/ostc-devs  @jeffaco

