### PR TITLE
Allow PPC builds to be identified as REDHAT, not ULINUX

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -92,6 +92,7 @@ case $uname in
         case `uname -m` in
 	    # ARCH is only used for OMS to determine the correct ruby folder
 	    ppc64*)
+                PF_DISTRO=REDHAT
                 PF_ARCH=ppc
                 ARCH=ppc
                 VERSION=`grep 'Red Hat Enterprise' /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`

--- a/installer/InstallBuilder/linuxrpm.py
+++ b/installer/InstallBuilder/linuxrpm.py
@@ -134,8 +134,6 @@ class LinuxRPMFile:
 
         specfile.close()
 
-        if self.variables['PFDISTRO'] == 'ULINUX' and self.variables['PFARCH'] == 'ppc':
-            self.variables['PFDISTRO']='REDHAT'
     def StageAndProperlyNameRPM(self):
         if 'OUTPUTFILE' in self.variables:
             rpmNewFileName = self.variables['OUTPUTFILE'] + '.rpm'

--- a/installer/InstallBuilder/unittests/ib_unittests.py
+++ b/installer/InstallBuilder/unittests/ib_unittests.py
@@ -252,6 +252,8 @@ if Variables["PF"] == "Linux":
         PACKAGE_TYPE = "RPM"
     elif (Variables["PFDISTRO"] == "ULINUX" and Variables["PF_DISTRO_ULINUX_KIT"] == "D"):
         PACKAGE_TYPE = "DPKG"
+    elif (Variables["PFDISTRO"] == "REDHAT" and Variables["PFARCH"] == "ppc"):
+        PACKAGE_TYPE = "RPM"
     else:
         error("Invalid Platform")
 elif Variables["PF"] == "AIX":


### PR DESCRIPTION
These builds only run on PPC platform (Power*) hosted by AIX

@Microsoft/ostc-devs 

RedHat PPC builds weren't quite right, BUILD_CONFIGURATION was still referring to ULINUX. Resolved this in configure script, which (I believe) negates one of the changes Nirbhay made to `installer/InstallBuilder/linuxrpm.py`.