### PR TITLE
Changing order of lib detection to be 64 bit first, if 64 bit system

### DIFF
--- a/source/code/scxcorelib/pal/scxlibglob.cpp
+++ b/source/code/scxcorelib/pal/scxlibglob.cpp
@@ -22,12 +22,12 @@ namespace SCXCoreLib
         // if directory paths are non-existant, provide default system library paths
         if (paths.size() == 0)
         {
-            m_paths.push_back(L"/lib");
-            m_paths.push_back(L"/usr/lib");
 #if PF_WIDTH == 64
             m_paths.push_back(L"/lib64");
             m_paths.push_back(L"/usr/lib64");
 #endif          
+            m_paths.push_back(L"/lib");
+            m_paths.push_back(L"/usr/lib");
         }
     }
     


### PR DESCRIPTION
On SLES12 x86_64, many libraries have both a 32 bit and 64 bit version.  On a 64 bit platform, we should be checking the 64 bit library directories first.