### PR TITLE
Fixing pbuild issue

### DIFF
--- a/source/code/include/scxsystemlib/statisticaldiskinstance.h
+++ b/source/code/include/scxsystemlib/statisticaldiskinstance.h
@@ -63,7 +63,7 @@ namespace SCXSystemLib
         virtual bool GetDiskSize(scxulong& mbUsed, scxulong& mbFree) const;
         virtual bool GetInodeUsage(scxulong& inodesTotal, scxulong& inodesFree) const;
         virtual bool GetBlockSize(scxulong& blockSize) const;
-        
+        virtual bool GetFSType(std::wstring& fsType) const;
         virtual bool GetHealthState(bool& healthy) const;
         
         virtual const std::wstring DumpString() const;

--- a/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
+++ b/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
@@ -595,5 +595,18 @@ namespace SCXSystemLib
         return -1;
     }
 
+    /*-------------------------------------------------------------------------------*/
+    /**
+       Retrieve the disk file system type.
+
+       \param        - output parameter where the file system type of the disk is stored.
+       \returns     true if value was set, otherwise false.
+    */
+    bool StatisticalDiskInstance::GetFSType(std::wstring& fsType) const
+    {
+        fsType = m_fsType;
+        return true;
+    }
+
 }
 /*----------------------------E-N-D---O-F---F-I-L-E---------------------------*/

--- a/test/code/scxsystemlib/disk/diskpal_test.cpp
+++ b/test/code/scxsystemlib/disk/diskpal_test.cpp
@@ -2165,6 +2165,7 @@ public:
         double secondsPerTransfer[3] = {0,0,0};
         scxulong mbUsed = 0;
         scxulong mbFree = 0;
+        bool excludeDeviceFreeSpace=false;
 #if defined(sun)
         scxulong tPercentage = 0;
 #endif
@@ -2176,7 +2177,19 @@ public:
             CPPUNIT_ASSERT(0 != disk);
             CPPUNIT_ASSERT(disk->GetDiskSize(mbu, mbf));
             mbUsed += mbu;
-            mbFree += mbf;
+#if defined(sun)
+           if (excludeDeviceFreeSpace)
+               excludeDeviceFreeSpace = false;
+           wstring m_name;
+           wstring m_fsType;
+           if(disk->GetFSType(m_fsType))
+           {
+               std:wstring mountDev=disk->DumpString();
+               if (m_fsType == L"zfs" && mountDev.find(L"/") != wstring::npos)
+                       excludeDeviceFreeSpace=true;
+            }
+#endif
+           mbFree += excludeDeviceFreeSpace?0:mbf;
 #if defined(aix)
             CPPUNIT_ASSERT( ! disk->GetReadsPerSecond(rps));
             CPPUNIT_ASSERT( ! disk->GetWritesPerSecond(wps));


### PR DESCRIPTION
pbuild was failing due to mismatch of free disk space in Total instance and free space calculated by adding from individual device instances in mnttab file. In case of solaris we should ignore the free space on each partition on zpool rather use free space on zpool itself. 

pbuild test result:
aix_7.1                 osdev16-aix71-01          Done (12:02)
hp_v3_ia64          osdevia-hpux31-01        Done (26:35)
sun_5.10_sparc    osdevsp-sol10-01          Done (14:20)
sun_5.10_x86       osdev86-sol10-01         Done (13:00)
sun_5.11_sparc    osdevsp-sol11-02          Done (14:23)
sun_5.11_x86       osdev86-sol11-01         Done (13:31)
suse_10_32          osdev-sles10-01            Done (13:20)
suse_10_64          osdev64-sles10-01        Done (11:00)

