### PR TITLE
Set ODMDIR environment variable to be the system ODM (not user).

### DIFF
--- a/source/code/scxsystemlib/common/scxodm.cpp
+++ b/source/code/scxsystemlib/common/scxodm.cpp
@@ -57,6 +57,7 @@ namespace SCXSystemLib
         SCXASSERT( ! m_fInitialized );
 
         m_lock.Lock();
+        (void)setenv("ODMDIR", "/etc/objrepos", 1);
         int status = odm_initialize();
         if ( 0 != status )
         {


### PR DESCRIPTION
Sometimes, omiserver will inherit the ODMDIR environment variable that isn't the system environment variable. This can prevent "odmget" commands from succeeding against certain ODM classes like "CuAt", which do not exist in ODM directories other than /etc/objrepos.  Our use of ODM only uses the "Cu" ODM interfaces so therefore we should always set this variable to /etc/objrepos.

This is AIX specific code, so this change only needs to be tested on AIX platforms. I've tested it with CM, but I've yet to test it with SCXCore (which I don't think this will effect). However, I can't imagine this would affect SCXCore negatively, as we never use any ODM class that isn't a "Cu"