### PR TITLE
tracefs need to be part of ignored FS list.

### DIFF
--- a/source/code/scxsystemlib/disk/diskdepend.cpp
+++ b/source/code/scxsystemlib/disk/diskdepend.cpp
@@ -681,7 +681,7 @@ namespace SCXSystemLib
             L"tmpfs",
             L"udfs", L"usbfs",
 #if defined(linux)
-            L"udev",
+            L"udev", L"tracefs",
 #endif
             L"vmblock", L"vmhgfs", L"vmware-hgfs",
 #if ! defined(sun)

--- a/test/code/scxsystemlib/disk/diskpal_test.cpp
+++ b/test/code/scxsystemlib/disk/diskpal_test.cpp
@@ -1167,7 +1167,7 @@ public:
             L"vmblock",     L"vmhgfs",      L"rpc_pipefs",  L"nfs",         L"usbfs",
             L"subfs",   L"fusectl",
 #if defined(linux)
-            L"udev", L"devtmpfs",
+            L"udev", L"devtmpfs", L"tracefs",
 #endif
             L"nfs",     L"DevFS",   L"autofs",
             L"cachefs", L"ffs", L"lofs",    L"nfs3",    L"procfs",
@@ -1289,7 +1289,7 @@ public:
             L"tmpfs",
             L"udfs", L"usbfs",
 #if defined(linux)
-            L"udev",
+            L"udev", L"tracefs",
 #endif
             L"vmblock", L"vmhgfs", L"vmware-hgfs",
 #if ! defined(sun)


### PR DESCRIPTION
"tracefs" is getting enumerated in disk enumeration as "tracefs" is not part of ignored file system. Due to this following error message keep on logging into scx.log file in each disk enumeration which leads to increase in scx log file size.

**"mount -l" command output with tracefs entry**:
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,relatime)
tracefs on /sys/kernel/debug/tracing type tracefs (rw,relatime,seclabel)

**Error Logged in scx.log file**
Did not find key 'tracefs' in proc_disk_stats map, device name was 'tracefs'.
The diskstats map does not contain a key matching the device named "tracefs", or only 0 columns were found

