### PR TITLE
disable extern "C" int getargs for latest AIX kernel

### DIFF
--- a/source/code/scxsystemlib/process/processinstance.cpp
+++ b/source/code/scxsystemlib/process/processinstance.cpp
@@ -61,7 +61,7 @@ extern "C" int getprocs64 (void *procsinfo, int sizproc, void *fdsinfo, int sizf
 
 #include <procinfo.h>
 
-extern "C" int getargs(struct procentry64*, int, char*, int);
+// extern "C" int getargs(struct procentry64*, int, char*, int);
 
 #endif // defined(aix)
 


### PR DESCRIPTION
we updated AIX to latest kernel which already define **extern "C" int getargs**, new this PR to fix the build break for scx. 
@sarojcare can you help to review this PR? thanks. 