### PR TITLE
Enabled testBootTime and testUpTime testcases

### DIFF
--- a/source/code/scxsystemlib/os/osinstance.cpp
+++ b/source/code/scxsystemlib/os/osinstance.cpp
@@ -130,6 +130,33 @@ struct LocaleInfo
     unsigned short DefaultCodePage;     // default Windows code page
 };
 
+struct utmpx32bits
+{
+    char ut_user[24] ;              /* User login name */
+    char ut_id[4] ;                 /* /etc/lines id(usually line #) */
+    char ut_line[12] ;              /* device name (console, lnxx) */
+    pid_t ut_pid ;                  /* process id */
+    short ut_type ;                 /* type of entry */
+    struct __exit_status
+    {
+        short __e_termination ;
+        short __e_exit ;
+    }
+    ut_exit;
+
+    unsigned short ut_reserved1 ;   /* Reserved for future use */
+    struct
+    {
+        int tv_sec;
+        int tv_usec;
+    } ut_tv;           /* time entry was made */
+
+    char ut_host[64] ;              /* host name, if remote;
+                                           NOT SUPPORTED */
+    uint32_t ut_addr ;              /* Internet addr of host, if remote */
+    char ut_reserved2[12] ; /* Reserved for future use */
+};
+
 static LocaleInfo LocaleInfoTable[] =
 {
     // English
@@ -791,8 +818,8 @@ namespace SCXSystemLib
         m_system_boot_isValid = false;
 
         int fd;
-        struct utmpx record;
-        int reclen = sizeof(struct utmpx);
+        struct utmpx32bits record;
+        int reclen = sizeof(struct utmpx32bits);
 
         fd = open(UTMPX_FILE, O_RDONLY);
         if (fd == -1){

--- a/source/code/scxsystemlib/os/osinstance.cpp
+++ b/source/code/scxsystemlib/os/osinstance.cpp
@@ -130,6 +130,7 @@ struct LocaleInfo
     unsigned short DefaultCodePage;     // default Windows code page
 };
 
+#if defined(hpux)
 struct utmpx32bits
 {
     char ut_user[24] ;              /* User login name */
@@ -156,6 +157,7 @@ struct utmpx32bits
     uint32_t ut_addr ;              /* Internet addr of host, if remote */
     char ut_reserved2[12] ; /* Reserved for future use */
 };
+#endif
 
 static LocaleInfo LocaleInfoTable[] =
 {
@@ -818,8 +820,13 @@ namespace SCXSystemLib
         m_system_boot_isValid = false;
 
         int fd;
+#if defined(hpux)
         struct utmpx32bits record;
         int reclen = sizeof(struct utmpx32bits);
+#else
+        struct utmpx record;
+        int reclen = sizeof(struct utmpx);
+#endif
 
         fd = open(UTMPX_FILE, O_RDONLY);
         if (fd == -1){

--- a/test/code/scxsystemlib/os/ospal_test.cpp
+++ b/test/code/scxsystemlib/os/ospal_test.cpp
@@ -111,8 +111,8 @@ class OSPAL_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( callDumpStringForCoverage );
     CPPUNIT_TEST( testTotalInstanceExists );
     CPPUNIT_TEST( testParseLangVariable );
-    //CPPUNIT_TEST( testBootTime );
-    //CPPUNIT_TEST( testUpTime );
+    CPPUNIT_TEST( testBootTime );
+    CPPUNIT_TEST( testUpTime );
     CPPUNIT_TEST_SUITE_END();
 
 private:


### PR DESCRIPTION
testBootTime and testUpTime test cases were failing for HP-UX because boot time read from
/etc/utmpx file was incorrect. It was found that program writing the boot time
in /etc/utmpx for HP-UX is a 32bit process and struct utmpx size was 140 bytes because
time_t tv_sec in 32bit process is a 32bit signed integer. In case of 64bit process time_t
corresponds to 64bit integer so sizeof struct utmpx is 152 bytes due to structure
padding. So when tv_sec was referenced in the struct utmpx then it was referring
to another variable corresponding to a 32bit struct whose value was 0.

This change declares a new struct utmpx32bits for HP-UX which defines tv_sec as 32bit signed
integer. Now sizeof struct utmpx32bits is 140 in 64bit program similar to sizeof
struct utmpx in 32bit program for HP-UX.