### PR TITLE
Fixes OSVersion to be accurate

### DIFF
--- a/source/code/scxsystemlib/common/GetLinuxOS.sh
+++ b/source/code/scxsystemlib/common/GetLinuxOS.sh
@@ -74,7 +74,7 @@ GetLinuxInfo() {
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
     # Try SLES
-    TestFile="${EtcPath}/SUSE-release"
+    TestFile="${EtcPath}/SuSE-release"
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
 
@@ -122,9 +122,11 @@ GetLinuxInfo() {
         OSName="Linux"
         Version=`uname -r | cut -d. -f1,2`
 
+        # check CentOS
+        [ ! -z $ReleaseFile ] && [ $(echo $(sed '/^$/d' ${ReleaseFile} | head -1) | grep "CentOS" | wc -l) -gt 0 ] && isCentOS=1
         # Do we have the (newer) os-release standard file?
         # If so, that trumps everything else
-        if [ -e "${EtcPath}/os-release" ]; then
+        if [ -e "${EtcPath}/os-release" -a -z "$isCentOS" ]; then
             ReleaseFile="${EtcPath}/os-release"
             GetKitType
 

--- a/test/code/scxsystemlib/common/getlinuxos_test.cpp
+++ b/test/code/scxsystemlib/common/getlinuxos_test.cpp
@@ -461,17 +461,17 @@ public:
         ExecuteScript( L"./testfiles/platforms/centos_7", releaseFile );
 
         // Verify our data:
-        //      OSName = CentOS Linux
-        //      OSVersion = 7.0
-        //      OSShortName=CentOS_7.0
-        //      OSFullName = CentOS Linux 7.0
+        //      OSName = CentOS
+        //      OSVersion = 7.1.1503
+        //      OSShortName = CentOS_7.1.1503
+        //      OSFullName = CentOS 7.1.1503
         //      OSAlias = UniversalR
         //      OSManufacturer = Central Logistics GmbH
 
-        CPPUNIT_ASSERT_EQUAL( string("CentOS Linux"), releaseFile["OSName"] );
-        CPPUNIT_ASSERT_EQUAL( string("7.0"), releaseFile["OSVersion"] );
-        CPPUNIT_ASSERT_EQUAL( string("CentOS_7.0"), releaseFile["OSShortName"] );
-        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("CentOS Linux 7.0") );
+        CPPUNIT_ASSERT_EQUAL( string("CentOS"), releaseFile["OSName"] );
+        CPPUNIT_ASSERT_EQUAL( string("7.1.1503"), releaseFile["OSVersion"] );
+        CPPUNIT_ASSERT_EQUAL( string("CentOS_7.1.1503"), releaseFile["OSShortName"] );
+        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("CentOS 7.1.1503") );
         CPPUNIT_ASSERT_EQUAL( string("UniversalR"), releaseFile["OSAlias"] );
         CPPUNIT_ASSERT_EQUAL( string("Central Logistics GmbH"), releaseFile["OSManufacturer"] );
     }


### PR DESCRIPTION
>OMS gets this info by reading a file generated by SCX (/etc/opt/microsoft/scx/conf/scx-release). For a CentOS 7.6 VM from azure marketplace my generated file was as below.
OSName=CentOS Linux
OSVersion=7.0
OSFullName=CentOS Linux 7.0 (x86_64)
OSAlias=UniversalR
OSManufacturer=Central Logistics GmbH
OSShortName=CentOS_7.0 

After fixes it uses `/etc/redhat-release` instead of `/etc/os-release`:
```
cat /etc/opt/microsoft/scx/conf/scx-release
OSName=CentOS
OSVersion=7.6.1810
OSFullName=CentOS 7.6.1810 (x86_64)
OSAlias=UniversalR
OSManufacturer=Central Logistics GmbH
OSShortName=CentOS_7.6.1810
```
