### PR TITLE
On RHEL8, process stat fails as it has process names > 28 chars

### DIFF
--- a/source/code/scxsystemlib/process/processinstance.cpp
+++ b/source/code/scxsystemlib/process/processinstance.cpp
@@ -204,7 +204,7 @@ namespace SCXSystemLib
         // "(" and last ")" to handle processes that contain "(" or ")" bytes.
         const char* procStart = strchr(buffer, '(');
         const char* procEnd = strrchr(buffer, ')');
-        if (NULL == procStart || NULL == procEnd || procStart > procEnd || (procEnd - procStart) > 28)
+        if (NULL == procStart || NULL == procEnd || procStart > procEnd || (procEnd - procStart) > 56)
         {
             wostringstream errtxt;
             errtxt << L"Unexpected error parsing " << StrFromUTF8(filename) << L", file contents: " << StrFromUTF8(buffer);


### PR DESCRIPTION
On RHEL8 platform process stat fails as it has certain process with name greater than 28 chars.
Ex:
root     20130     2  0 04:39 ?        00:00:00 [kworker/0:2-cgroup_pidlist_destroy]
root     20352     2  0 04:43 ?        00:00:00 [kworker/u128:1-events_unbound]
root     20753     2  0 04:51 ?        00:00:00 [kworker/u128:2-events_unbound]
root     21033     2  0 04:57 ?        00:00:00 [kworker/0:3-events_power_efficient]
root     21035     2  0 04:57 ?        00:00:00 [kworker/u128:0-events_unbound]
 
It is risk to not check size at can be potential security risk. Hence increased the size.