### PR TITLE
There are certain SUSE platform on which release info file is named as

### DIFF
--- a/source/code/scxsystemlib/common/GetLinuxOS.sh
+++ b/source/code/scxsystemlib/common/GetLinuxOS.sh
@@ -74,7 +74,7 @@ GetLinuxInfo() {
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
     # Try SLES
-    TestFile="${EtcPath}/SUSE-release"
+    TestFile=`ls -F ${EtcPath}/*-release 2>/dev/null | grep -i SUSE`
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
 


### PR DESCRIPTION
There are certain SUSE platform on which release info file is named as
SuSE-release instead of SUSE-release. As linux platform is inherently
case sensitive it wonot be able to find such file and hence system may
eventually get discovered under universal MP instead of SuSE12 MP. With
this change release file name will be searched in case-insensitive way
and hence able to discover such platforms appropriately.