### PR TITLE
OES platform support & Customize release file selection.

### DIFF
--- a/source/code/scxsystemlib/common/GetLinuxOS.sh
+++ b/source/code/scxsystemlib/common/GetLinuxOS.sh
@@ -12,7 +12,7 @@ Hostname=`uname -n`
 OSName=`uname -s`
 Version=`uname -r`      # Version
 Arch=`uname -m`         # Overridden as uname -p on some platforms
-ReleaseFile=""
+ReleaseFile=`echo $PLATFORM_RELEASE_FILE_SCX_INSTALLER_INPUT`
 EtcPath="/etc"
 
 # Create destination directory if it does not exist
@@ -74,7 +74,7 @@ GetLinuxInfo() {
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
     # Try SLES
-    TestFile="${EtcPath}/SUSE-release"
+    TestFile="${EtcPath}/SuSE-release"
     if [ -f $TestFile ]; then ReleaseFile=$TestFile; fi
 
 


### PR DESCRIPTION
Description:
Release file on SuSE platform is 'SuSE-release', but it is coded
as SUSE-release instead. In general, it is not an issue on most
SuSE platforms as release file name is appropriately getting set
using 'ls -F /etc/*-release' command. But on OES platform, a variant
of SuSE platform, the release file name not getting set appropriately when
there are locales defined. Also as linux platform is inherently case-
sensitive it won't be able to select SuSE-release file as well due to
this typo. Hence OES system is eventually get detected as universal
platform instead of SuSE. Hence rectified the typo. Also added provision to
customize release file selection through env variable to handle such
variances.