### PR TITLE
100% cpu isssue in omiagent

### DIFF
--- a/source/code/scxsystemlib/disk/diskdepend.cpp
+++ b/source/code/scxsystemlib/disk/diskdepend.cpp
@@ -375,9 +375,21 @@ namespace SCXSystemLib
         SCXCoreLib::SCXHandle<std::wfstream> fsDiskStats(SCXCoreLib::SCXFile::OpenWFstream(LocateProcDiskStats(), std::ios::in));
         fsDiskStats.SetOwner();
         std::wstring line;
-        while ( ! fsDiskStats->eof() && fsDiskStats->is_open() )
+        int counter = 0;
+        while ( fsDiskStats->good() && fsDiskStats->is_open() )
         {
             getline( *fsDiskStats, line );
+            if ( line.size() )
+                counter = 0;
+            else
+                ++counter;
+
+            if ( counter >= 10 )
+            {
+                SCX_LOGERROR(m_log, L"Error while refreshing diskstats with errno = " + SCXCoreLib::StrFrom(errno));
+                break;
+            }
+
             std::vector<std::wstring> parts;
             SCXCoreLib::StrTokenize(line, parts, L" \n\t");
             if (parts.size() < 3)


### PR DESCRIPTION
Below are the few points that would be helpful while reviewing the fix:
1.	This code get executed while sampling the disk stats data. Sampling period is 60 seconds.
2.	This code runs in the context of two threads parallelly.
a.	SCX_DiskDriveStatisticalInformation enumeration query
b.	SCX_FileSystemStatisticalInformation enumeration query
3.	While analyzing core dumps , for few of the data sets, I observed errno is getting set to 9 (bad file descriptor).
4.	Once it is infinite loop, every time it read empty (””) string from file “/proc/diskstats” whereas content of the file is appropriate.
5.	“/proc/diskstats” is a kind of virtual file, when you read data from it, basically you are reading from kernel memory. For better performance and all, it does not have any locking mechanism and all.
6.	My best guess is, because of logical error or read/write error on i/o operation, fstream is going in bad state.
7.	Our current code check only for eof state whereas it does not check for failbit and badbit.
8.	Behaviour of failbit and badbit is not that very well defined like under what condition what exactly will get set across the various OS. For example in my local system, failbit also gets set under eof condition. 
9.	Checking for good bit is the best bet for us here instead of individual error bit.
10.	Another defensive approach is to check if continuously we are getting empty string while reading from “/proc/diskstats”, let us say 10 times, break the loop with logging. 
11.	For now I have kept both of fix (check for good bit and defensive approach).
