### PR TITLE
Add -ggdb and -g for pal

### DIFF
--- a/build/Makefile.gcc3
+++ b/build/Makefile.gcc3
@@ -53,9 +53,9 @@ ifeq ($(PF_DISTRO),REDHAT)
 	endif
 endif
 
-# CXX Debug flags for debug builds
+# CXX flags
+CXXFLAGS += -ggdb
 ifeq ($(BUILD_TYPE),Debug)
-	CXXFLAGS += -ggdb 
 	DEFINES += -D_DEBUG
 else
 	DEFINES += -DNDEBUG

--- a/build/Makefile.pf.AIX
+++ b/build/Makefile.pf.AIX
@@ -31,7 +31,7 @@ ifeq ($(BUILD_TYPE),Debug)
 # 	COMMONFLAGS += -qheapdebug     Currently disabled, see WI11161
 	DEFINES += -D_DEBUG
 else
-	COMMONFLAGS += -O2 -qcompact
+	COMMONFLAGS += -g -O2 -qcompact
 	DEFINES += -DNDEBUG
 endif
 

--- a/build/Makefile.pf.SunOS
+++ b/build/Makefile.pf.SunOS
@@ -68,7 +68,7 @@ ifeq ($(ARCH),sparc)
 	LDFLAGS_COMMON += -xcheck=%all
 endif
 else
-	CXXFLAGS += -xO1
+	CXXFLAGS += -g -xO1
 	DEFINES += -DNDEBUG
 	LDFLAGS_COMMON += -xldscope=hidden
 ifeq ($(ARCH),sparc)


### PR DESCRIPTION
@microsoft/omi-devs This fixes to support https://github.com/microsoft/SCXcore/pull/170, so the debug symbol folder will be created during generate packages.