### PR TITLE
Fixes oracle 7 OSShortName issue in GetLinuxOS.sh

### DIFF
--- a/source/code/scxsystemlib/common/GetLinuxOS.sh
+++ b/source/code/scxsystemlib/common/GetLinuxOS.sh
@@ -180,6 +180,16 @@ GetLinuxInfo() {
                         OSShortName="Ubuntu"
                     fi
                     ;;
+
+                ol)
+                    OSManufacturer="Oracle Corporation"
+                    OSAlias="UniversalR"
+                    if [ "${Version}" != "" ]; then
+                        OSShortName="Oracle_"
+                    else
+                        OSShortName="Oracle"
+                    fi
+                    ;;
             esac
 
         elif [ ! -z $ReleaseFile ]; then

--- a/test/code/scxsystemlib/common/getlinuxos_test.cpp
+++ b/test/code/scxsystemlib/common/getlinuxos_test.cpp
@@ -49,6 +49,7 @@ class SCXGetLinuxOS_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( TestPlatform_SLES_10 );
     CPPUNIT_TEST( TestPlatform_Oracle_5 );
     CPPUNIT_TEST( TestPlatform_Oracle_6 );
+    CPPUNIT_TEST( TestPlatform_Oracle_7 );
     CPPUNIT_TEST( TestPlatform_NeoKylin );
     CPPUNIT_TEST( TestPlatform_Debian_5_0_10 );
     CPPUNIT_TEST( TestPlatform_Ubuntu_11 );
@@ -357,6 +358,29 @@ public:
         CPPUNIT_ASSERT_EQUAL( string("6.0"), releaseFile["OSVersion"] );
         CPPUNIT_ASSERT_EQUAL( string("Oracle_6.0"), releaseFile["OSShortName"] );
         CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("Oracle Linux Server 6.0") );
+        CPPUNIT_ASSERT_EQUAL( string("UniversalR"), releaseFile["OSAlias"] );
+        CPPUNIT_ASSERT_EQUAL( string("Oracle Corporation"), releaseFile["OSManufacturer"] );
+    }
+
+    // Platform Oracle Enterprise Linux 7:
+    void TestPlatform_Oracle_7()
+    {
+        SelfDeletingFilePath delReleaseFile( s_wsReleaseFile );
+        map<string,string> releaseFile;
+        ExecuteScript( L"./testfiles/platforms/oracle_7", releaseFile );
+
+        // Verify our data:
+        //      OSName=Oracle Linux Server
+        //      OSVersion=7.0
+        //      OSFullName=Oracle Linux Server 7.0 (x86_64)
+        //      OSAlias=UniversalR
+        //      OSManufacturer=Oracle Corporation
+        //      OSShortName=Oracle_7.0
+
+        CPPUNIT_ASSERT_EQUAL( string("Oracle Linux Server"), releaseFile["OSName"] );
+        CPPUNIT_ASSERT_EQUAL( string("7.0"), releaseFile["OSVersion"] );
+        CPPUNIT_ASSERT_EQUAL( string("Oracle_7.0"), releaseFile["OSShortName"] );
+        CPPUNIT_ASSERT_EQUAL( static_cast<size_t>(0), releaseFile["OSFullName"].find("Oracle Linux Server 7.0") );
         CPPUNIT_ASSERT_EQUAL( string("UniversalR"), releaseFile["OSAlias"] );
         CPPUNIT_ASSERT_EQUAL( string("Oracle Corporation"), releaseFile["OSManufacturer"] );
     }

--- a/test/code/scxsystemlib/common/platforms/oracle_7/oracle-release
+++ b/test/code/scxsystemlib/common/platforms/oracle_7/oracle-release
@@ -1,0 +1,1 @@
+Oracle Linux Server release 7.0

--- a/test/code/scxsystemlib/common/platforms/oracle_7/os-release
+++ b/test/code/scxsystemlib/common/platforms/oracle_7/os-release
@@ -1,0 +1,14 @@
+NAME="Oracle Linux Server"
+VERSION="7.0"
+ID="ol"
+VERSION_ID="7.0"
+PRETTY_NAME="Oracle Linux Server 7.0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:oracle_linux:7.0:GA:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.0
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION=7.0

--- a/test/code/scxsystemlib/common/platforms/oracle_7/redhat-release
+++ b/test/code/scxsystemlib/common/platforms/oracle_7/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux Server release 7.0 (Maipo)

--- a/test/code/scxsystemlib/common/platforms/oracle_7/system-release
+++ b/test/code/scxsystemlib/common/platforms/oracle_7/system-release
@@ -1,0 +1,1 @@
+Oracle Linux Server release 7.0


### PR DESCRIPTION
@microsoft/omi-devs This PR fixes OSShortName issue for oracle 7, and also adds related unit tests for GetLinuxOS.sh in getlinuxos_test.cpp and the unit tests passed locally.