### PR TITLE
File system's memory related parameter is different from Linux command DF

### DIFF
--- a/source/code/include/scxsystemlib/statisticaldiskinstance.h
+++ b/source/code/include/scxsystemlib/statisticaldiskinstance.h
@@ -60,7 +60,7 @@ namespace SCXSystemLib
         virtual bool GetIOTimes(double& read, double& write) const;
         virtual bool GetIOTimesTotal(double& total) const;
         virtual bool GetDiskQueueLength(double& value) const;
-        virtual bool GetDiskSize(scxulong& mbUsed, scxulong& mbFree) const;
+        virtual bool GetDiskSize(scxulong& mbUsed, scxulong& mbFree, scxulong& mbTotal) const;
         virtual bool GetInodeUsage(scxulong& inodesTotal, scxulong& inodesFree) const;
         virtual bool GetBlockSize(scxulong& blockSize) const;
         virtual bool GetFSType(std::wstring& fsType) const;
@@ -127,6 +127,7 @@ namespace SCXSystemLib
         double m_secPerTransfer;   //!< Seconds per transfer
         scxulong m_mbUsed;         //!< MB used
         scxulong m_mbFree;         //!< MB free
+        scxulong m_mbTotal;        //!< MB Total
         scxulong m_blockSize;      //!< Disk block size
         double m_qLength;          //!< Average disk queue length
         scxulong m_inodesTotal;    //!< Total inodes

--- a/source/code/include/scxsystemlib/statisticalphysicaldiskinstance.h
+++ b/source/code/include/scxsystemlib/statisticalphysicaldiskinstance.h
@@ -35,7 +35,7 @@ namespace SCXSystemLib
         virtual bool GetReadsPerSecond(scxulong& value) const;
         virtual bool GetWritesPerSecond(scxulong& value) const;
         virtual bool GetBytesPerSecond(scxulong& read, scxulong& write) const;
-        virtual bool GetDiskSize(scxulong& mbUsed, scxulong& mbFree) const;
+        virtual bool GetDiskSize(scxulong& mbUsed, scxulong& mbFree, scxulong& mbTotal) const;
         virtual bool GetBlockSize(scxulong& blockSize) const;
 
         virtual void Sample();

--- a/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
+++ b/source/code/scxsystemlib/disk/statisticaldiskinstance.cpp
@@ -103,6 +103,7 @@ namespace SCXSystemLib
         m_secPerTransfer = 0;
         m_mbUsed = 0;
         m_mbFree = 0;
+        m_mbTotal = 0;
         m_inodesTotal = 0;
         m_inodesFree = 0;
         m_blockSize = 0;
@@ -136,6 +137,7 @@ namespace SCXSystemLib
 
         m_mbFree = 0;
         m_mbUsed = 0;
+        m_mbTotal = 0;
         m_inodesTotal = 0;
         m_inodesFree = 0;
         m_readsPerSec = m_reads.GetAverageDelta(MAX_DISKINSTANCE_DATASAMPER_SAMPLES) / DISK_SECONDS_PER_SAMPLE;
@@ -223,7 +225,8 @@ namespace SCXSystemLib
                 // when using system commands.
                 m_mbFree = static_cast<scxulong>(ceil(SCXCoreLib::BytesToMegaBytes(static_cast<double>(s_vfs.f_bavail)*static_cast<double>(s_vfs.f_frsize))));
                 m_mbUsed = static_cast<scxulong>(ceil(SCXCoreLib::BytesToMegaBytes((static_cast<double>(s_vfs.f_blocks)-
-                                                                                    static_cast<double>(s_vfs.f_bavail))*static_cast<double>(s_vfs.f_frsize))));
+                                                                                    static_cast<double>(s_vfs.f_bfree))*static_cast<double>(s_vfs.f_frsize))));
+                m_mbTotal = static_cast<scxulong>(ceil(SCXCoreLib::BytesToMegaBytes(static_cast<double>(s_vfs.f_blocks)*static_cast<double>(s_vfs.f_frsize))));
                 m_blockSize = s_vfs.f_bsize;
 
                 // Grab the inode information while we have it
@@ -488,10 +491,11 @@ namespace SCXSystemLib
     \param       mbFree - output parameter where MBs free on disk is stored.
     \returns     true if value was set, otherwise false.
 */
-    bool StatisticalDiskInstance::GetDiskSize(scxulong& mbUsed, scxulong& mbFree) const
+    bool StatisticalDiskInstance::GetDiskSize(scxulong& mbUsed, scxulong& mbFree, scxulong& mbTotal) const
     {
         mbUsed = m_mbUsed;
         mbFree = m_mbFree; 
+        mbTotal = m_mbTotal; 
         return true;
     }
 

--- a/source/code/scxsystemlib/disk/statisticallogicaldiskenumeration.cpp
+++ b/source/code/scxsystemlib/disk/statisticallogicaldiskenumeration.cpp
@@ -301,6 +301,7 @@ namespace SCXSystemLib
                 total->m_waitTime += disk->m_waitTime;
                 total->m_mbUsed += disk->m_mbUsed;
                 total->m_mbFree += excludeDeviceFreeSpace?0:disk->m_mbFree;
+                total->m_mbTotal += disk->m_mbTotal;
                 total_reads += disk->m_reads.GetDelta(MAX_DISKINSTANCE_DATASAMPER_SAMPLES);
                 total_writes += disk->m_writes.GetDelta(MAX_DISKINSTANCE_DATASAMPER_SAMPLES);
 #if defined (hpux)

--- a/source/code/scxsystemlib/disk/statisticalphysicaldiskenumeration.cpp
+++ b/source/code/scxsystemlib/disk/statisticalphysicaldiskenumeration.cpp
@@ -259,6 +259,7 @@ namespace SCXSystemLib
                 total->m_waitTime += disk->m_waitTime;
                 total->m_mbUsed += disk->m_mbUsed;
                 total->m_mbFree += disk->m_mbFree;
+                total->m_mbTotal += disk->m_mbTotal;
                 total_reads += disk->m_reads.GetDelta(MAX_DISKINSTANCE_DATASAMPER_SAMPLES);
                 total_writes += disk->m_writes.GetDelta(MAX_DISKINSTANCE_DATASAMPER_SAMPLES);
 #if defined (hpux)

--- a/source/code/scxsystemlib/disk/statisticalphysicaldiskinstance.cpp
+++ b/source/code/scxsystemlib/disk/statisticalphysicaldiskinstance.cpp
@@ -84,9 +84,9 @@ namespace SCXSystemLib
 /**
    \copydoc SCXSystemLib::StatisticalDiskInstance::GetDiskSize
 */
-    bool StatisticalPhysicalDiskInstance::GetDiskSize(scxulong& mbUsed, scxulong& mbFree) const
+    bool StatisticalPhysicalDiskInstance::GetDiskSize(scxulong& mbUsed, scxulong& mbFree, scxulong& mbTotal) const
     {
-        mbUsed = mbFree = 0;
+        mbUsed = mbFree = mbTotal = 0;
         return false;
     }
 

--- a/test/code/scxsystemlib/disk/diskpal_test.cpp
+++ b/test/code/scxsystemlib/disk/diskpal_test.cpp
@@ -756,12 +756,12 @@ loop1      0      0       0       0      0      0       0       0      0      0
                         disk->m_fs = parts[1];
                         disk->m_mountPoint = parts[6];
                         disk->m_name = disk->m_mountPoint;
-                        disk->m_mbUsed = SCXCoreLib::StrToULong(parts[2]) - SCXCoreLib::StrToULong(parts[4]);
+                        disk->m_mbUsed = SCXCoreLib::StrToULong(parts[3]);
                         disk->m_mbFree = SCXCoreLib::StrToULong(parts[4]);
 #elif defined(aix) || defined(hpux) || defined (sun)
                         disk->m_mountPoint = parts[5];
                         disk->m_name = disk->m_mountPoint;
-                        disk->m_mbUsed = SCXCoreLib::StrToULong(parts[1]) - SCXCoreLib::StrToULong(parts[3]);
+                        disk->m_mbUsed = SCXCoreLib::StrToULong(parts[2]);
                         disk->m_mbFree = SCXCoreLib::StrToULong(parts[3]);
                         disk->m_mbUsed = static_cast<scxulong>(ceil(disk->m_mbUsed/1024.0));
                         disk->m_mbFree = static_cast<scxulong>(ceil(disk->m_mbFree/1024.0));
@@ -1542,8 +1542,8 @@ public:
                 CPPUNIT_ASSERT_MESSAGE(StrToUTF8(GetExpectFoundPhysical(disks)), 0 != disk);
 
                 // Disk size
-                scxulong mbFree, mbUsed;
-                CPPUNIT_ASSERT( ! disk->GetDiskSize(mbUsed, mbFree));
+                scxulong mbFree, mbUsed, mbTotal;
+                CPPUNIT_ASSERT( ! disk->GetDiskSize(mbUsed, mbFree, mbTotal));
 
                 // Block size
                 scxulong blocksize;
@@ -1587,8 +1587,8 @@ public:
                 CPPUNIT_ASSERT(0 != disk);
 
                 // Disk size
-                scxulong mbFree, mbUsed;
-                CPPUNIT_ASSERT(disk->GetDiskSize(mbUsed, mbFree));
+                scxulong mbFree, mbUsed, mbTotal;
+                CPPUNIT_ASSERT(disk->GetDiskSize(mbUsed, mbFree, mbTotal));
                 if (L"zfs" != td->m_fs)
                 {
 #if defined(hpux)
@@ -2171,11 +2171,11 @@ public:
 #endif
         for (SCXSystemLib::EntityEnumeration<SCXSystemLib::StatisticalLogicalDiskInstance>::EntityIterator iter = m_diskEnumLogical->Begin(); iter != m_diskEnumLogical->End(); iter++)
         {
-            scxulong rps, wps, tps, rbps, wbps, tbps, mbu, mbf;
+            scxulong rps, wps, tps, rbps, wbps, tbps, mbu, mbf, mbt;
             double spr, spw, spt;
             SCXCoreLib::SCXHandle<SCXSystemLib::StatisticalLogicalDiskInstance> disk = *iter;
             CPPUNIT_ASSERT(0 != disk);
-            CPPUNIT_ASSERT(disk->GetDiskSize(mbu, mbf));
+            CPPUNIT_ASSERT(disk->GetDiskSize(mbu, mbf, mbt));
             mbUsed += mbu;
 #if defined(sun)
            if (excludeDeviceFreeSpace)
@@ -2259,7 +2259,7 @@ public:
             secondsPerTransfer[AVG_VALUE] = secondsPerTransfer[AVG_VALUE] / static_cast<double>(m_diskEnumLogical->Size());
         }
         SCXCoreLib::SCXHandle<SCXSystemLib::StatisticalLogicalDiskInstance> total = m_diskEnumLogical->GetTotalInstance();
-        scxulong rps, wps, tps, rbps, wbps, tbps, mbu, mbf;
+        scxulong rps, wps, tps, rbps, wbps, tbps, mbu, mbf, mbt;
         double spr, spw, spt;
         CPPUNIT_ASSERT(0 != total);
 #if defined(aix)
@@ -2288,7 +2288,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(rBytesPerSecond, rbps);
         CPPUNIT_ASSERT_EQUAL(wBytesPerSecond, wbps);
         CPPUNIT_ASSERT_EQUAL(tBytesPerSecond, tbps);
-        CPPUNIT_ASSERT(total->GetDiskSize(mbu, mbf));
+        CPPUNIT_ASSERT(total->GetDiskSize(mbu, mbf, mbt));
         CPPUNIT_ASSERT_EQUAL(mbUsed, mbu);
         CPPUNIT_ASSERT_EQUAL(mbFree, mbf);
 #if defined(aix) || defined(linux)


### PR DESCRIPTION
SCX provider does not handle reserve memory at file system level same as Linux command 'df' handles, which causes difference in  memory related parameters in SCX_FileSystemStatisticalInformation enumeration query. This PR takes care of that issue.