### PR TITLE
Fixing OMIagent crash as part of log rotate

### DIFF
--- a/source/code/scxcorelib/util/log/scxlogfilebackend.cpp
+++ b/source/code/scxcorelib/util/log/scxlogfilebackend.cpp
@@ -121,12 +121,15 @@ namespace SCXCoreLib
      */
     void SCXLogFileBackend::HandleLogRotate()
     {
-        m_LogFileRunningNumber++;
-        m_FileStream->close();
-        m_FileStream = 0;
-        SCXLogItem item(L"scx.core.providers", eInfo, L"Log rotation complete", 
-                        SCXSRCLOCATION, SCXThread::GetCurrentThreadID());
-        DoLogItem(item);
+        if (m_FileStream != 0 &&  m_FileStream->is_open())
+        {
+            m_LogFileRunningNumber++;
+            m_FileStream->close();
+            m_FileStream = 0;
+            SCXLogItem item(L"scx.core.providers", eInfo, L"Log rotation complete", 
+                    SCXSRCLOCATION, SCXThread::GetCurrentThreadID());
+            DoLogItem(item);
+        }
     }
 
     /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
Scenario here is: If omiagent has not recevived a single log msg request means file stream has not been initialized at all and subsequent log rotate request will result into crash while attemping to closing uninitialized file stream. 
Most of the time, omiagent running under user 'omi' does not have any log msg and log rotate result into crash this instance. 