### PR TITLE
Issue 903261 timeout not working on shell command when using elevation

### DIFF
--- a/source/code/include/scxcorelib/scxprocess.h
+++ b/source/code/include/scxcorelib/scxprocess.h
@@ -108,6 +108,7 @@ namespace SCXCoreLib
         virtual ~SCXProcess();
         void Kill();
         unsigned GetEffectiveTimeout(unsigned timeout);
+        std::wstring ConstructShellCommandWithElevation(const std::wstring &command, const std::wstring &elevationtype);
 
     protected:
         virtual bool ReadToStream(int fd, std::ostream& stream);


### PR DESCRIPTION
When using ExcecuteShellCommand (or Script) with a specific Timeout, when using ElevationType sudo, the Timeout is ignored and does not work. This is because the monitoring thread checking the timeout, when trying to kill (killpg) the running process (that is executing the command/script) will fail with EPERM (access denied) because we are running (omiagent) with an unprivileged account, while the process that we are trying to kill is running as privileged as root due to the fact that when constructing the command, we will include SUDO. There is also another issue here that when this will actually throw an Exception (that is what is happening when EPERM will happen) the thread goes away and we swallow the exception without showing it or logging it anywhere. 